### PR TITLE
Remove generics from access control package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "access-control"
-version = "2.1.0"
+version = "2.0.0"
 dependencies = [
  "create_type_spec_derive",
  "pbc_contract_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "access-control"
-version = "2.0.0"
+version = "2.1.1"
 dependencies = [
  "create_type_spec_derive",
  "pbc_contract_codegen",
@@ -900,7 +900,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "meta-names-contract"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "access-control",
  "contract-version-base",

--- a/access-control/Cargo.toml
+++ b/access-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "access-control"
-version = "2.0.0"
+version = "2.1.1"
 edition = "2021"
 
 [lib]

--- a/access-control/Cargo.toml
+++ b/access-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "access-control"
-version = "2.1.0"
+version = "2.0.0"
 edition = "2021"
 
 [lib]
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 pbc_contract_common = { workspace = true }
 pbc_contract_codegen = { workspace = true }
-pbc_traits = { workspace = true, features = ["abi"] }
+pbc_traits = { workspace = true }
 pbc_lib = { workspace = true }
 read_write_rpc_derive = { workspace = true }
 read_write_state_derive = { workspace = true }

--- a/access-control/src/actions.rs
+++ b/access-control/src/actions.rs
@@ -2,23 +2,17 @@ use pbc_contract_common::context::ContractContext;
 
 use crate::{
     msg::{ACInitMsg, ACRoleMsg, ACSetAdminRoleMsg},
-    state::AccessControlState,
+    state::{AccessControlState, DEFAULT_ADMIN_ROLE},
     ContractError,
 };
 
 /// Initializes access control extension state
-pub fn execute_init<RoleEnum: Ord + Clone>(
-    msg: ACInitMsg<RoleEnum>,
-) -> AccessControlState<RoleEnum> {
-    let mut state = AccessControlState::<RoleEnum>::new();
-    state._setup_role(
-        msg.admin_role.clone(),
-        msg.admin_role.clone(),
-        &msg.admin_addresses,
-    );
+pub fn execute_init(msg: &ACInitMsg) -> AccessControlState {
+    let mut state = AccessControlState::default();
+    state._setup_role(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE, &msg.admin_addresses);
 
     for role in msg.additional_roles.iter() {
-        state._setup_role(role.clone(), msg.admin_role.clone(), &[]);
+        state._setup_role(*role, DEFAULT_ADMIN_ROLE, &[]);
     }
 
     state
@@ -26,54 +20,39 @@ pub fn execute_init<RoleEnum: Ord + Clone>(
 
 /// Grants specified tole to specified account
 /// Throws error if caller is not admin of specified role
-pub fn execute_grant_role<RoleEnum: Ord + Clone>(
-    ctx: &ContractContext,
-    state: &mut AccessControlState<RoleEnum>,
-    msg: &ACRoleMsg<RoleEnum>,
-) {
-    let admin_role = state.get_role_admin(msg.role.clone());
-    assert!(admin_role.is_some(), "{}", ContractError::MissingAdminRole);
+pub fn execute_grant_role(ctx: &ContractContext, state: &mut AccessControlState, msg: &ACRoleMsg) {
+    let admin_role = state.get_role_admin(msg.role).unwrap_or(DEFAULT_ADMIN_ROLE);
+    execute_assert_only_role(state, admin_role, ctx);
 
-    execute_assert_only_role(state, admin_role.unwrap(), ctx);
-    state._set_role(msg.role.clone(), &msg.account);
+    state._set_role(msg.role, &msg.account);
 }
 
 /// Revokes specified tole from specified account
 /// Throws error if caller is not admin of specified role
-pub fn execute_revoke_role<RoleEnum: Ord + Clone>(
-    ctx: &ContractContext,
-    state: &mut AccessControlState<RoleEnum>,
-    msg: &ACRoleMsg<RoleEnum>,
-) {
-    let admin_role = state.get_role_admin(msg.role.clone());
-    assert!(admin_role.is_some(), "{}", ContractError::MissingAdminRole);
+pub fn execute_revoke_role(ctx: &ContractContext, state: &mut AccessControlState, msg: &ACRoleMsg) {
+    let admin_role = state.get_role_admin(msg.role).unwrap_or(DEFAULT_ADMIN_ROLE);
+    execute_assert_only_role(state, admin_role, ctx);
 
-    execute_assert_only_role(state, admin_role.unwrap(), ctx);
-    state._revoke_role(msg.role.clone(), &msg.account);
+    state._revoke_role(msg.role, &msg.account);
 }
 
 /// Sets new tole admin for role
 /// Throws error if caller is not admin of specified role
-pub fn execute_set_role_admin<RoleEnum: Ord + Clone>(
+pub fn execute_set_role_admin(
     ctx: &ContractContext,
-    state: &mut AccessControlState<RoleEnum>,
-    msg: &ACSetAdminRoleMsg<RoleEnum>,
+    state: &mut AccessControlState,
+    msg: &ACSetAdminRoleMsg,
 ) {
-    let admin_role = state.get_role_admin(msg.role.clone());
-    assert!(admin_role.is_some(), "{}", ContractError::MissingAdminRole);
+    let admin_role = state.get_role_admin(msg.role).unwrap_or(DEFAULT_ADMIN_ROLE);
+    execute_assert_only_role(state, admin_role, ctx);
 
-    execute_assert_only_role(state, admin_role.unwrap(), ctx);
-    state._set_role_admin(msg.role.clone(), msg.new_admin_role.clone());
+    state._set_role_admin(msg.role, msg.new_admin_role);
 }
 
 /// Validates that only specified role member can have access
-pub fn execute_assert_only_role<RoleEnum: Ord + Clone>(
-    state: &AccessControlState<RoleEnum>,
-    role: &RoleEnum,
-    ctx: &ContractContext,
-) {
+pub fn execute_assert_only_role(state: &AccessControlState, role: u8, ctx: &ContractContext) {
     assert!(
-        state.has_role(role.clone(), &ctx.sender),
+        state.has_role(role, &ctx.sender),
         "{}",
         ContractError::MissingRole
     );

--- a/access-control/src/error.rs
+++ b/access-control/src/error.rs
@@ -5,6 +5,4 @@ use thiserror::Error;
 pub enum ContractError {
     #[error("AccessControl-base: Specified address is missing role")]
     MissingRole,
-    #[error("AccessControl-base: Specified role is missing the admin role")]
-    MissingAdminRole,
 }

--- a/access-control/src/msg.rs
+++ b/access-control/src/msg.rs
@@ -1,17 +1,16 @@
 use pbc_contract_common::address::Address;
 
-pub struct ACInitMsg<RoleEnum> {
-    pub admin_role: RoleEnum,
+pub struct ACInitMsg {
     pub admin_addresses: Vec<Address>,
-    pub additional_roles: Vec<RoleEnum>,
+    pub additional_roles: Vec<u8>,
 }
 
-pub struct ACRoleMsg<RoleEnum> {
-    pub role: RoleEnum,
+pub struct ACRoleMsg {
+    pub role: u8,
     pub account: Address,
 }
 
-pub struct ACSetAdminRoleMsg<RoleEnum> {
-    pub role: RoleEnum,
-    pub new_admin_role: RoleEnum,
+pub struct ACSetAdminRoleMsg {
+    pub role: u8,
+    pub new_admin_role: u8,
 }

--- a/access-control/src/state.rs
+++ b/access-control/src/state.rs
@@ -1,93 +1,94 @@
 use pbc_contract_common::{
-    address::Address,
-    context::ContractContext,
-    sorted_vec_map::{SortedVecMap, SortedVecSet},
+    address::Address, context::ContractContext, sorted_vec_map::SortedVecMap,
 };
-use pbc_traits::CreateTypeSpec;
-use pbc_traits::ReadWriteState;
 use read_write_state_derive::ReadWriteState;
 
-use std::collections::BTreeMap;
+pub const DEFAULT_ADMIN_ROLE: u8 = 0x00;
 
 /// This structure describes access control extension state
 #[repr(C)]
-#[derive(ReadWriteState, Clone, PartialEq, Eq, Debug, Default)]
-pub struct AccessControlState<RoleEnum: Ord + Clone> {
-    pub roles_admin: SortedVecMap<RoleEnum, RoleEnum>,
-    pub roles_addresses: SortedVecSet<RoleAddress<RoleEnum>>,
+#[derive(ReadWriteState, CreateTypeSpec, Clone, PartialEq, Eq, Debug, Default)]
+pub struct AccessControlState {
+    /// configured roles
+    pub roles: SortedVecMap<u8, Role>,
 }
 
 /// This structure describes role with some granted access control
 #[repr(C)]
-#[derive(ReadWriteState, Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
-pub struct RoleAddress<RoleEnum: Ord + Clone> {
-    pub role: RoleEnum,
-    pub address: Address,
+#[derive(ReadWriteState, CreateTypeSpec, Clone, PartialEq, Eq, Debug)]
+pub struct Role {
+    /// configured admin role
+    pub admin_role: u8,
+    /// whitelisted role members
+    pub members: Vec<Address>,
 }
 
-impl<RoleEnum: Ord + Clone> AccessControlState<RoleEnum> {
-    pub fn new() -> Self {
-        AccessControlState {
-            roles_admin: Default::default(),
-            roles_addresses: Default::default(),
-        }
-    }
-
+impl AccessControlState {
     /// Returns either address has specified role or not
-    pub fn has_role(&self, role: RoleEnum, address: &Address) -> bool {
-        let role_address = &RoleAddress {
-            role,
-            address: *address,
-        };
+    pub fn has_role(&self, role: u8, account: &Address) -> bool {
+        if let Some(role) = self.roles.get(&role) {
+            return role.members.contains(account);
+        }
 
-        self.roles_addresses.contains(role_address)
+        false
     }
 
     /// Returns admin role of specified role
-    pub fn get_role_admin(&self, role: RoleEnum) -> Option<&RoleEnum> {
-        self.roles_admin.get(&role)
+    pub fn get_role_admin(&self, role: u8) -> Option<u8> {
+        if let Some(role) = self.roles.get(&role) {
+            return Some(role.admin_role);
+        }
+
+        None
     }
 
     /// Setups new role
-    pub fn _setup_role(&mut self, role: RoleEnum, admin_role: RoleEnum, accounts: &[Address]) {
-        self._set_role_admin(role.clone(), admin_role);
+    pub fn _setup_role(&mut self, role: u8, admin_role: u8, accounts: &[Address]) {
+        self._set_role_admin(role, admin_role);
 
         for account in accounts {
-            self._set_role(role.clone(), account);
+            self._set_role(role, account);
         }
     }
 
     /// Removes role access for specified account
-    pub fn _revoke_role(&mut self, role: RoleEnum, address: &Address) {
-        if self.has_role(role.clone(), address) {
-            self.roles_addresses.remove(&RoleAddress {
-                role,
-                address: *address,
-            });
+    pub fn _revoke_role(&mut self, role: u8, account: &Address) {
+        if self.has_role(role, account) {
+            let role = self.roles.get_mut(&role).unwrap();
+            role.members.retain(|addr| addr != account)
         }
     }
 
     /// Removes sender access to role
-    pub fn _renounce_role(&mut self, role: RoleEnum, ctx: &ContractContext) {
-        if self.has_role(role.clone(), &ctx.sender) {
-            self.roles_addresses.remove(&RoleAddress {
-                role,
-                address: ctx.sender,
-            });
+    pub fn _renounce_role(&mut self, role: u8, ctx: &ContractContext) {
+        if self.has_role(role, &ctx.sender) {
+            let role = self.roles.get_mut(&role).unwrap();
+            role.members.retain(|addr| addr != &ctx.sender)
         }
     }
 
     /// Sets new tole admin for role
-    pub fn _set_role_admin(&mut self, role: RoleEnum, admin_role: RoleEnum) {
-        self.roles_admin.insert(role, admin_role);
+    pub fn _set_role_admin(&mut self, role: u8, admin_role: u8) {
+        match self.roles.get_mut(&role) {
+            Some(role) => role.admin_role = admin_role,
+            None => {
+                self.roles.insert(
+                    role,
+                    Role {
+                        admin_role,
+                        members: vec![],
+                    },
+                );
+            }
+        }
     }
 
-    pub fn _set_role(&mut self, role: RoleEnum, address: &Address) {
-        if !self.has_role(role.clone(), address) {
-            self.roles_addresses.insert(RoleAddress {
-                role,
-                address: *address,
-            });
+    pub fn _set_role(&mut self, role: u8, account: &Address) {
+        if !self.has_role(role, account) {
+            match self.roles.get_mut(&role) {
+                Some(role) => role.members.push(*account),
+                None => panic!("Role not found"),
+            }
         }
     }
 }

--- a/access-control/src/state.rs
+++ b/access-control/src/state.rs
@@ -1,3 +1,4 @@
+use create_type_spec_derive::CreateTypeSpec;
 use pbc_contract_common::{
     address::Address, context::ContractContext, sorted_vec_map::SortedVecMap,
 };
@@ -90,32 +91,5 @@ impl AccessControlState {
                 None => panic!("Role not found"),
             }
         }
-    }
-}
-
-// Implementations to fix the CreateTypeSpec bug
-#[cfg(feature = "abi")]
-impl<RoleEnum: CreateTypeSpec + Ord + Clone> CreateTypeSpec for AccessControlState<RoleEnum> {
-    fn __ty_name() -> String {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_name()
-    }
-    fn __ty_identifier() -> String {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_identifier()
-    }
-    fn __ty_spec_write(w: &mut Vec<u8>, lut: &BTreeMap<String, u8>) {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_spec_write(w, lut)
-    }
-}
-
-#[cfg(feature = "abi")]
-impl<RoleEnum: CreateTypeSpec + Ord + Clone> CreateTypeSpec for RoleAddress<RoleEnum> {
-    fn __ty_name() -> String {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_name()
-    }
-    fn __ty_identifier() -> String {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_identifier()
-    }
-    fn __ty_spec_write(w: &mut Vec<u8>, lut: &BTreeMap<String, u8>) {
-        SortedVecMap::<RoleEnum, RoleEnum>::__ty_spec_write(w, lut)
     }
 }

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -16,7 +16,7 @@ read_write_rpc_derive = { workspace = true }
 read_write_state_derive = { workspace = true }
 create_type_spec_derive = { workspace = true }
 
-access-control = { path = "../access-control", features = ["abi"] }
+access-control = { path = "../access-control" }
 contract-version-base = { path = "../contract-version-base" }
 partisia-name-system = { path = "../partisia-name-system" }
 nft = { path = "../nft" }

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -47,10 +47,9 @@ pub fn initialize(ctx: ContractContext, msg: InitMsg) -> (ContractState, Vec<Eve
             uri_template: msg.uri_template,
         },
     );
-    let access_control = ac_actions::execute_init(ac_msg::ACInitMsg::<UserRole> {
-        admin_role: UserRole::Admin {},
+    let access_control = ac_actions::execute_init(&ac_msg::ACInitMsg {
         admin_addresses: msg.admin_addresses,
-        additional_roles: vec![UserRole::Whitelist {}],
+        additional_roles: vec![UserRole::Whitelist {} as u8],
     });
 
     let state = ContractState {
@@ -186,7 +185,7 @@ pub fn mint(
 
     let is_admin = mut_state
         .access_control
-        .has_role(UserRole::Admin {}, &ctx.sender);
+        .has_role(UserRole::Admin {} as u8, &ctx.sender);
     if parent_id.is_some() || is_admin {
         let (new_state, mint_events) =
             action_mint(ctx, mut_state, domain, to, token_uri, parent_id, None);
@@ -198,7 +197,7 @@ pub fn mint(
         if mut_state.config.whitelist_enabled {
             let is_whitelisted = mut_state
                 .access_control
-                .has_role(UserRole::Whitelist {}, &ctx.sender);
+                .has_role(UserRole::Whitelist {} as u8, &ctx.sender);
             assert!(is_whitelisted, "{}", ContractError::UserNotWhitelisted);
         }
 
@@ -330,7 +329,7 @@ pub fn update_user_role(
             &ctx,
             &mut state.access_control,
             &ac_msg::ACRoleMsg {
-                role,
+                role: role as u8,
                 account: address,
             },
         );
@@ -339,7 +338,7 @@ pub fn update_user_role(
             &ctx,
             &mut state.access_control,
             &ac_msg::ACRoleMsg {
-                role,
+                role: role as u8,
                 account: address,
             },
         );
@@ -356,7 +355,7 @@ pub fn update_config(
 ) -> (ContractState, Vec<EventGroup>) {
     let is_admin = state
         .access_control
-        .has_role(UserRole::Admin {}, &ctx.sender);
+        .has_role(UserRole::Admin {} as u8, &ctx.sender);
     assert!(is_admin, "{}", ContractError::Unauthorized);
 
     state.config = config;
@@ -389,7 +388,7 @@ pub fn renew_subscription(
 
     let is_admin = state
         .access_control
-        .has_role(UserRole::Admin {}, &ctx.sender);
+        .has_role(UserRole::Admin {} as u8, &ctx.sender);
 
     let events;
     if is_admin {

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -13,7 +13,7 @@ use crate::contract::__PBC_IS_ZK_CONTRACT;
 #[state]
 #[derive(PartialEq, Eq, Default, Clone, Debug)]
 pub struct ContractState {
-    pub access_control: AccessControlState<UserRole>,
+    pub access_control: AccessControlState,
     pub config: ContractConfig,
     pub nft: NFTContractState,
     pub pns: PartisiaNameSystemState,
@@ -32,21 +32,12 @@ pub struct PayableMintInfo {
 }
 
 #[repr(u8)]
-#[derive(
-    ReadWriteRPC, ReadWriteState, CreateTypeSpec, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug,
-)]
+#[derive(ReadWriteRPC, ReadWriteState, CreateTypeSpec, PartialEq, Eq, Copy, Clone, Debug)]
 pub enum UserRole {
     #[discriminant(0)]
     Admin {},
     #[discriminant(1)]
     Whitelist {},
-}
-
-// Implement the default manually as cannot use the derive macro
-impl Default for UserRole {
-    fn default() -> Self {
-        UserRole::Admin {}
-    }
 }
 
 #[repr(C)]

--- a/contract/tests/cucumber.rs
+++ b/contract/tests/cucumber.rs
@@ -348,7 +348,7 @@ fn mint_counts(world: &mut ContractWorld, user: String, count: u32) {
 #[then(regex = r"(\w+) user (has|has not) the (\w+) role")]
 fn user_is_admin(world: &mut ContractWorld, user: String, has: String, role: String) {
     let has_role = world.state.access_control.has_role(
-        get_user_role(role),
+        get_user_role(role) as u8,
         &mock_address(get_address_for_user(user)),
     );
 


### PR DESCRIPTION
Unfortunately, generics are not well supported by the CreateTypeSpec macro. Removing 